### PR TITLE
Update all dependencies and fix examples with shadowed computed fields

### DIFF
--- a/examples/audit-log-context/package.json
+++ b/examples/audit-log-context/package.json
@@ -5,14 +5,14 @@
     "dev": "ts-node script.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1"
+    "@prisma/client": "^4.9.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@types/node": "^18.11.13",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/examples/callback-free-itx/package.json
+++ b/examples/callback-free-itx/package.json
@@ -5,14 +5,14 @@
     "dev": "ts-node script.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1"
+    "@prisma/client": "^4.9.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@types/node": "^18.11.13",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/examples/computed-fields/package.json
+++ b/examples/computed-fields/package.json
@@ -5,14 +5,14 @@
     "dev": "ts-node script.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1"
+    "@prisma/client": "^4.9.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@types/node": "^18.11.12",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/examples/input-transformation/package.json
+++ b/examples/input-transformation/package.json
@@ -5,14 +5,14 @@
     "dev": "ts-node script.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1"
+    "@prisma/client": "^4.9.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@types/node": "^18.11.12",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/examples/input-validation/package.json
+++ b/examples/input-validation/package.json
@@ -5,14 +5,14 @@
     "dev": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1",
-    "zod": "^3.19.1"
+    "@prisma/client": "^4.9.0",
+    "zod": "^3.20.2"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@types/node": "^18.11.12",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   }
 }

--- a/examples/instance-methods/package.json
+++ b/examples/instance-methods/package.json
@@ -5,13 +5,13 @@
     "dev": "ts-node script.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1"
+    "@prisma/client": "^4.9.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@types/node": "^18.11.12",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   }
 }

--- a/examples/json-field-types/README.md
+++ b/examples/json-field-types/README.md
@@ -11,8 +11,6 @@ This example includes a `User` model with a JSON `profile` field, which has a sp
 
 > **NOTE**: Query extensions do not currently work for nested operations. In this example, validations are only run on the top level `data` object passed to methods such as `prisma.user.create()`. Validations implemented this way do not automatically run for [nested writes](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#nested-writes).
 
-> **NOTE**: There is currently [an open issue](https://github.com/prisma/prisma/issues/16643) regarding `result` extensions that shadow a field with the same name as one of their dependencies. As a workaround, the transformed field in this example is named `createdAtFormatted`, but in the future this will likely be changed to `createdAt` to shadow the underlying transformed field.
-
 Prisma Client extensions are currently in developer preview. This extension is provided as an example only. It is not intended to be used in production environments.
 
 Please read the documentation on [`query` extensions](https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions/query) and [`result` extensions](https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions/query) for more information.

--- a/examples/json-field-types/package.json
+++ b/examples/json-field-types/package.json
@@ -5,15 +5,15 @@
     "dev": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1",
-    "zod": "^3.19.1"
+    "@prisma/client": "^4.9.0",
+    "zod": "^3.20.2"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@types/node": "^18.11.13",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/examples/json-field-types/src/index.ts
+++ b/examples/json-field-types/src/index.ts
@@ -1,10 +1,11 @@
-import { PrismaClient, Prisma } from "@prisma/client";
+import * as runtime from "@prisma/client/runtime/index";
+import { PrismaClient, Prisma, UserPayload } from "@prisma/client";
 import { Profile } from "./schemas";
 
 const prisma = new PrismaClient().$extends({
   result: {
     user: {
-      profileData: {
+      profile: {
         needs: { profile: true },
         compute({ profile }) {
           return Profile.parse(profile);
@@ -49,7 +50,8 @@ const prisma = new PrismaClient().$extends({
   },
 });
 
-type User = Prisma.UserGetPayload<{}, typeof prisma["$extends"]["extArgs"]>;
+type ExtArgs = UserPayload<typeof prisma["$extends"]["extArgs"]>;
+type User = runtime.Types.GetResult<ExtArgs, {}, "findUniqueOrThrow">;
 
 async function main() {
   const users = await prisma.user.findMany({ take: 10 });
@@ -59,7 +61,7 @@ async function main() {
 function renderUser({
   id,
   email,
-  profileData: { firstName, lastName, avatar, contactInfo, socialLinks },
+  profile: { firstName, lastName, avatar, contactInfo, socialLinks },
 }: User) {
   const card = [
     "===============================================================================",

--- a/examples/model-filters/package.json
+++ b/examples/model-filters/package.json
@@ -5,16 +5,16 @@
     "dev": "ts-node script.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1",
+    "@prisma/client": "^4.9.0",
     "cuid": "^2.1.8",
     "date-fns": "^2.29.3"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@types/node": "^18.11.13",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/examples/obfuscated-fields/package.json
+++ b/examples/obfuscated-fields/package.json
@@ -5,16 +5,16 @@
     "dev": "ts-node script.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1",
+    "@prisma/client": "^4.9.0",
     "bcryptjs": "^2.4.3"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
     "@types/bcryptjs": "^2.4.2",
-    "@types/node": "^18.11.12",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/examples/query-logging/package.json
+++ b/examples/query-logging/package.json
@@ -5,14 +5,14 @@
     "dev": "ts-node script.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1"
+    "@prisma/client": "^4.9.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@types/node": "^18.11.13",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/examples/readonly-client/package.json
+++ b/examples/readonly-client/package.json
@@ -5,14 +5,14 @@
     "dev": "ts-node script.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1"
+    "@prisma/client": "^4.9.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@types/node": "^18.11.12",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/examples/retry-transactions/package.json
+++ b/examples/retry-transactions/package.json
@@ -5,15 +5,15 @@
     "dev": "ts-node script.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1",
+    "@prisma/client": "^4.9.0",
     "exponential-backoff": "^3.1.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@types/node": "^18.11.13",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/examples/row-level-security/package.json
+++ b/examples/row-level-security/package.json
@@ -5,14 +5,14 @@
     "dev": "ts-node script.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1"
+    "@prisma/client": "^4.9.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@types/node": "^18.11.13",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/examples/static-methods/package.json
+++ b/examples/static-methods/package.json
@@ -5,15 +5,15 @@
     "dev": "ts-node script.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1",
+    "@prisma/client": "^4.9.0",
     "bcryptjs": "^2.4.3"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
     "@types/bcryptjs": "^2.4.2",
-    "@types/node": "^18.11.12",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   }
 }

--- a/examples/transformed-fields/README.md
+++ b/examples/transformed-fields/README.md
@@ -6,8 +6,6 @@ This example shows a way to implement internationalization (i18n) at the data ac
 
 ## Caveats
 
-> **NOTE**: There is currently [an open issue](https://github.com/prisma/prisma/issues/16643) regarding `result` extensions that shadow a field with the same name as one of their dependencies. As a workaround, the transformed field in this example is named `createdAtFormatted`, but in the future this will likely be changed to `createdAt` to shadow the underlying transformed field.
-
 Prisma Client extensions are currently in developer preview. This extension is provided as an example only. It is not intended to be used in production environments.
 
 Please read [the documentation on `result` extensions](https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions/result) for more information.

--- a/examples/transformed-fields/package.json
+++ b/examples/transformed-fields/package.json
@@ -5,15 +5,15 @@
     "dev": "ts-node script.ts"
   },
   "dependencies": {
-    "@prisma/client": "^4.7.1",
+    "@prisma/client": "^4.9.0",
     "date-fns": "^2.29.3"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@types/node": "^18.11.13",
-    "prisma": "^4.7.1",
+    "@types/node": "^18.11.18",
+    "prisma": "^4.9.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/examples/transformed-fields/script.ts
+++ b/examples/transformed-fields/script.ts
@@ -5,7 +5,7 @@ import { PrismaClient } from "@prisma/client";
 const prisma = new PrismaClient().$extends({
   result: {
     post: {
-      createdAtFormatted: {
+      createdAt: {
         needs: { createdAt: true },
         compute(post) {
           return formatDistanceToNow(post.createdAt, {
@@ -22,7 +22,7 @@ async function main() {
   const posts = await prisma.post.findMany({ take: 5 });
 
   for (const post of posts) {
-    console.info(`- ${post.title} (${post.createdAtFormatted})`);
+    console.info(`- ${post.title} (${post.createdAt})`);
   }
 }
 


### PR DESCRIPTION
This PR updates all dependencies to the latest versions, and updates the two examples which use computed fields that depend on model fields of the same name. This now works nicely since [this bug](https://github.com/prisma/prisma/issues/16643) has been fixed.