### PR TITLE
Migrate `json-field-types` to prisma 5

### DIFF
--- a/json-field-types/package.json
+++ b/json-field-types/package.json
@@ -5,13 +5,13 @@
     "dev": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@prisma/client": "4.16.1",
+    "@prisma/client": "5.0.0",
     "zod": "3.21.4"
   },
   "devDependencies": {
     "@faker-js/faker": "7.6.0",
     "@types/node": "18.16.18",
-    "prisma": "4.16.1",
+    "prisma": "5.0.0",
     "ts-node": "10.9.1",
     "typescript": "4.9.5"
   },

--- a/json-field-types/src/index.ts
+++ b/json-field-types/src/index.ts
@@ -1,5 +1,4 @@
-import * as runtime from "@prisma/client/runtime/library";
-import { PrismaClient, UserPayload } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { Profile } from "./schemas";
 
 const prisma = new PrismaClient().$extends({
@@ -50,10 +49,7 @@ const prisma = new PrismaClient().$extends({
   },
 });
 
-type ExtArgs = (typeof prisma)["$extends"]["extArgs"];
-type User = NonNullable<
-  runtime.Types.GetResult<UserPayload<ExtArgs>, ExtArgs, "findFirst">
->;
+type User = Prisma.Result<typeof prisma.user, {}, "findFirstOrThrow">;
 
 async function main() {
   const users = await prisma.user.findMany({ take: 10 });

--- a/json-field-types/src/index.ts
+++ b/json-field-types/src/index.ts
@@ -1,5 +1,5 @@
-import * as runtime from "@prisma/client/runtime/index";
-import { PrismaClient, Prisma, UserPayload } from "@prisma/client";
+import * as runtime from "@prisma/client/runtime/library";
+import { PrismaClient, UserPayload } from "@prisma/client";
 import { Profile } from "./schemas";
 
 const prisma = new PrismaClient().$extends({
@@ -50,8 +50,10 @@ const prisma = new PrismaClient().$extends({
   },
 });
 
-type ExtArgs = UserPayload<typeof prisma["$extends"]["extArgs"]>;
-type User = runtime.Types.GetResult<ExtArgs, {}, "findUniqueOrThrow">;
+type ExtArgs = (typeof prisma)["$extends"]["extArgs"];
+type User = NonNullable<
+  runtime.Types.GetResult<UserPayload<ExtArgs>, ExtArgs, "findFirst">
+>;
 
 async function main() {
   const users = await prisma.user.findMany({ take: 10 });


### PR DESCRIPTION
In this pull request, I addressed a compatibility issue with Prisma 5 discovered in the https://github.com/prisma/prisma-client-extensions/tree/main/json-field-types

After migrating to Prisma 5, I observed that the user profile ([link to code](https://github.com/prisma/prisma-client-extensions/blob/main/json-field-types/src/index.ts#L54)) was not inferring the correct types, maintaining `Prisma.JsonValue` instead of the anticipated shape.

![Screen Shot 2023-07-18 at 1 27 29 PM](https://github.com/prisma/prisma-client-extensions/assets/116004898/4ac20cf2-a2ad-4abb-b233-fff64240e79d)


To resolve this, the pull request updates the Prisma package to version 5.0.0 and modifies the type inference mechanism to no longer depend on the internal API.

