### PR TITLE
Block the executeRaw, queryRawUnsafe and executeRawUnsafe in readonly-client.

### DIFF
--- a/readonly-client/script.ts
+++ b/readonly-client/script.ts
@@ -14,6 +14,7 @@ const GLOBAL_WRITE_METHODS = [
     '$executeRaw',
     '$queryRawUnsafe',
     '$executeRawUnsafe',
+    '$runCommandRaw',
 ] as const;
 
 const ReadonlyClient = Prisma.defineExtension({

--- a/readonly-client/script.ts
+++ b/readonly-client/script.ts
@@ -37,11 +37,11 @@ const ReadonlyClient = Prisma.defineExtension({
   query: Object.fromEntries(
     GLOBAL_WRITE_METHODS.map((method) => [
         method,
-        function (args: any) {
+        function (args: never) {
           throw new Error(`Calling the \`${method}\` method on a readonly client is not allowed`);
         }
     ])) as {
-        [K in typeof GLOBAL_WRITE_METHODS[number]]: (args: any) => never;
+        [K in typeof GLOBAL_WRITE_METHODS[number]]: (args: `Calling the \`${K}\` method on a readonly client is not allowed`) => never;
     }
 });
 

--- a/readonly-client/script.ts
+++ b/readonly-client/script.ts
@@ -6,6 +6,7 @@ const WRITE_METHODS = [
   "upsert",
   "delete",
   "createMany",
+  "createManyAndReturn",
   "updateMany",
   "deleteMany",
 ] as const;


### PR DESCRIPTION
The global methods that modify the database where still allowed.